### PR TITLE
Fix console error

### DIFF
--- a/src/headhesive.js
+++ b/src/headhesive.js
@@ -38,8 +38,10 @@
         // Merge user options with default options
         this.options = _mergeObj(this.options, options);
 
-        // Self init
-        this.init();
+        // Self init if elem exists
+        if (this.elem === null) {
+            this.init();
+        }
     };
 
 


### PR DESCRIPTION
If the Headhesive constructor is called on a node that doesn't exist on the page, a console error is thrown, because cloneNode is then called against `null`. This change suggests checking that `elem` is set before calling the `init` func.
